### PR TITLE
Refined "How to Use the Kit" and "Accessible"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,13 @@ Please see the [contributing doc](https://github.com/bocoup/opendesignkit/blob/m
 * To explore practical ways to get from design to development in a flow that works for both sides
 
 # How to Use the Kit
-### Bocoupers
 There is no set order of operations for getting started with the kit.  The idea is that once you find yourself in a jam, you can reference the kit to identify tools and practices to support you in getting from problem identification to solution.
 
-The kit also helps to bridge the gap between the work of design and the work of implementing a design, there are ideas and thoughts about how to do that and hopefully help the process go smoothly.
-
-### Everyone else
-This was built using the design principals documented with in it. Our target user were other bocoupers and so the documentation was written with specific personas in mind. It's our belief that Design kits are not generic. What works for one community/company might not suit another.
-
-We encourage you to fork this repo and use it to build a design kit that suits your needs. Interview your team members and create your own personas, so you know what needs your team has. Then modify, add and remove based on their needs and goals.
+The kit also helps to bridge the gap between the work of design and the work of implementing a design, there are ideas and thoughts about how to do that and hopefully help the process go smoothly. Design kits are not generic. What works for one community/company might not suit another. If the methods in here don't resonate with you that's totally ok, and better yet - submit ones that do! 
 
 
 # Accessible design, by and for everyone
-While these practices have been road tested for open source projects, they can be used by anyone, anywhere on any project. If that isn’t the case, go ahead a remix them! Design should be accessible and responsive to the unique needs of specific inquiries and problems.
+While these practices have been road tested for open source projects, they can be used by anyone, anywhere on any project. If that isn’t the case, go ahead a remix them! Design should be accessible and responsive to the unique needs of specific inquiries, problems and abilities.
 
 # Contributing to the wiki
 Please to do not modify the wiki directly.  Add and edit files inside the wiki folder and submit them as PRs.


### PR DESCRIPTION
I removed the disambiguation between "Bocoupers" and "everyone else" - seeing that this kit is open, we should really try to write it in a way that speaks to any potential user. In this sense, everyone is a Bocouper. 

I added the word "abilities" to our statement on accessibility because the word accessible connotes that it is [a11y compliant](https://wiki.openoffice.org/wiki/Accessibility_(A11y)_Quick_Test_Check_List). We might even want to say that outright.