### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you are adding a new method:
 An alternative method for the more technically inclined, is to push these edits to the wiki use the docs.sh bash script.  Run: `sh docs.sh `
 
 # How to Use the Kit
-There is no set order of operations for getting started with the kit.  The idea is that once you find yourself in a jam, you can reference the kit to identify tools and practices to support you in getting from problem identification to solution, you can see the various tools on the [wiki](https://github.com/bocoup/opendesignkit/wiki).
+There is no set order of operations for getting started with the kit.  The idea is that once you find yourself in a jam, you can reference the kit to identify tools and practices to support you in getting from problem identification to solution, check out all the [methods](https://github.com/bocoup/opendesignkit/wiki/Method-Guides).
 
 The kit also helps to bridge the gap between the work of design and the work of implementing a design, there are ideas and thoughts about how to do that and hopefully help the process go smoothly. Design kits are not generic. What works for one community/company might not suit another. If the methods in here don't resonate with you that's totally ok, and better yet - submit ones that do!
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Since 2009, Bocoup has been creating, championing, and continually improving ope
 
 
 # Key Documents
-- [Hypotheses](https://github.com/bocoup/opendesignkit/wiki/Hypotheses)
-- [Project Brief](https://github.com/bocoup/opendesignkit/wiki/Open-Design-Kit:-Design-Brief)
+- [Hypotheses](https://github.com/bocoup/opendesignkit/wiki/Hypotheses) Our believes about design that we are using the Open Design Kit to investigate
+- [Project Brief](https://github.com/bocoup/opendesignkit/wiki/Open-Design-Kit:-Design-Brief) The Open Design Kit's purpose and requirements.
 
 
 # What's the big idea?
-Design literacy needs to be constantly developed and improved throughout the software and product development industry. Designers must constantly  level up their skillsets with lifelong learning. Engineers often need to learn how to collaborate and incorporate new practices into their workflow to successfully support the integration of design. Clients and stakeholders are repeatedly challenged by the fact that design is a verb, not a noun that is handed off, but a verb that needs constant attention. To address this, Bocoup is openly compiling a suite of learning materials, methods, and systems to help our staff, clients, colleagues, and community better understand how we design and when to roll up their sleeves and get in on the action. It is our hope that this exploration will be useful for other companies and individuals to incorporate into their practice. 
+Design literacy needs to be constantly developed and improved throughout the software and product development industry. Designers must constantly  level up their skillsets with lifelong learning. Engineers often need to learn how to collaborate and incorporate new practices into their workflow to successfully support the integration of design. Clients and stakeholders are repeatedly challenged by the fact that design is a verb, not a noun that is handed off, but a verb that needs constant attention. To address this, Bocoup is openly compiling a suite of learning materials, methods, and systems to help our staff, clients, colleagues, and community better understand how we design and when to roll up their sleeves and get in on the action. It is our hope that this exploration will be useful for other companies and individuals to incorporate into their practice.
 
 So, why does the world need another compilation of tools? Here’s why:
 - To establish what it means to design in the open, with practical methods designed for distributed collaborators.
@@ -28,7 +28,7 @@ If you are adding a new method:
 - **Step 1:** Submit an issue identifying the method that you would like to include.
 - **Step 2:** Go to the "wiki" folder in this repo - and find the "Method-Guide-Template.md" file - and open it.
 - **Step 3:** Copy the template from the markdown file. (This can be done by clicking the Edit :pencil: and selecting all of the text and then "copying"it. Once this is done, close the markdown file - and make sure not to save any changes).
-- **Step 4:** Now go back to the wiki folder and select the "Create new file" button. Now in the Edit file section, paste all of the text. Be sure to name the file with your method. It should look like: opendesignkit/wiki/[methodname].md 
+- **Step 4:** Now go back to the wiki folder and select the "Create new file" button. Now in the Edit file section, paste all of the text. Be sure to name the file with your method. It should look like: opendesignkit/wiki/[methodname].md
 - **Step 5:** Write your method. Please keep in mind the design values and the primary goal of our kit being for distributed teams.
 - **Step 6:** Create a pull request. This can be done by scrolling to the bottom of the page where it says "commit new file". You should name the commit by including the method in the title. Then write a brief extended description. Finally, select the radio button titled "Create a new branch for this commit and start a pull request. Learn more about pull requests." Then select the "Commit new file" button.
 - **Step 7:** Fill out the github issue for the pull request. If you know another contributor on the project, this would be a good place to mention them as well as the issue that you wrote about the method in _Step 1_
@@ -40,7 +40,7 @@ An alternative method for the more technically inclined, is to push these edits 
 # How to Use the Kit
 There is no set order of operations for getting started with the kit.  The idea is that once you find yourself in a jam, you can reference the kit to identify tools and practices to support you in getting from problem identification to solution.
 
-The kit also helps to bridge the gap between the work of design and the work of implementing a design, there are ideas and thoughts about how to do that and hopefully help the process go smoothly. Design kits are not generic. What works for one community/company might not suit another. If the methods in here don't resonate with you that's totally ok, and better yet - submit ones that do! 
+The kit also helps to bridge the gap between the work of design and the work of implementing a design, there are ideas and thoughts about how to do that and hopefully help the process go smoothly. Design kits are not generic. What works for one community/company might not suit another. If the methods in here don't resonate with you that's totally ok, and better yet - submit ones that do!
 
 
 # Accessible design, by and for everyone

--- a/README.md
+++ b/README.md
@@ -38,13 +38,15 @@ If you are adding a new method:
 An alternative method for the more technically inclined, is to push these edits to the wiki use the docs.sh bash script.  Run: `sh docs.sh `
 
 # How to Use the Kit
-There is no set order of operations for getting started with the kit.  The idea is that once you find yourself in a jam, you can reference the kit to identify tools and practices to support you in getting from problem identification to solution.
+There is no set order of operations for getting started with the kit.  The idea is that once you find yourself in a jam, you can reference the kit to identify tools and practices to support you in getting from problem identification to solution, you can see the various tools on the [wiki](https://github.com/bocoup/opendesignkit/wiki).
 
 The kit also helps to bridge the gap between the work of design and the work of implementing a design, there are ideas and thoughts about how to do that and hopefully help the process go smoothly. Design kits are not generic. What works for one community/company might not suit another. If the methods in here don't resonate with you that's totally ok, and better yet - submit ones that do!
 
 
 # Accessible design, by and for everyone
 While these practices have been road tested for open source projects, they can be used by anyone, anywhere on any project. If that isn’t the case, go ahead a remix them! Design should be accessible and responsive to the unique needs of specific inquiries, problems and abilities.
+
+[Check out the wiki to see what methods are available.](https://github.com/bocoup/opendesignkit/wiki)
 
 
 # Inspiration


### PR DESCRIPTION
This is based on comments by @bmac in #61.

There are two things he mentions that I think should be done in other issues. The first is this:

> The "What's the big idea?" broadly mentions several roles like designer, engineer, client and stakeholder and the challenges they have interacting with the design process. I found this interesting and wished there was a page when I could look and see that "my role is X" and I am expected to be involved in tools "Journey Maps" and "Interviews".

We don't have a page like that so that would need to be created. BUT I also think if that page is created we need to be careful to say that anyone can do anything, but that certain roles will naturally do some of the methods.

The other is:

>The terms "design literacy" and "design thinking" are used but never defined.

I'm not sure if we should define these? Or is there somewhere we can link to that will define them? But if we do link to a definition we should also define other terms such as open source.

@iamjessklein let me know what you think. But I really think this issue is close to done (this is always something we can iterate on and change in the future as well).