### PR TITLE
switch gem requirements to just jekyll 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem 'jekyll-multiple-languages-plugin'
+gem "jekyll"


### PR DESCRIPTION
Currently the plugin is not in use. 
Reducing the installation requirements eases contributor participation. 