### PR TITLE
GitHub is written with an uppercase H

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing & Collaboration Guidelines
-We have a ton of issues on [Github](https://github.com/bocoup/opendesignkit/issues) specifically labeled for contributors. Right now we could use support localizing the methods, testing out the methods, and reporting outright bugs.
+We have a ton of issues on [GitHub](https://github.com/bocoup/opendesignkit/issues) specifically labeled for contributors. Right now we could use support localizing the methods, testing out the methods, and reporting outright bugs.
 
 ## More information
 We've outlined various ways to contribute on our [site](http://opendesignkit.org/contribute), so please refer to that. But either creating issues or creating a pull request are great ways to help us out. We can use both of those for discussion to move forward.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 # About
-[Bocoup](https://bocoup.com/)'s Design team maintains Open Design Kit as an open source tool. It's design for collaborators who are not co-located, with a variety of skill levels. No prior design experience is required for you to try out these methods, just an open mind. The Kit includes activities from ideation to implementation and is meant to evolve with use. To share your feedback or add a method, open an issue or pull request on our Github repository.
+[Bocoup](https://bocoup.com/)'s Design team maintains Open Design Kit as an open source tool. It's design for collaborators who are not co-located, with a variety of skill levels. No prior design experience is required for you to try out these methods, just an open mind. The Kit includes activities from ideation to implementation and is meant to evolve with use. To share your feedback or add a method, open an issue or pull request on our GitHub repository.
 
 Since 2009, Bocoup has been creating, championing, and continually improving open tools and workflows used around the world. We foster environments of inclusivity and individuality as we dedicate ourselves to solving global market challenges in the public sphere. We bring diverse experience and leadership to all of our projects so developers and users can accomplish more.
 

--- a/_methods/interviews.md
+++ b/_methods/interviews.md
@@ -31,7 +31,7 @@ Small (1 - 2 hours); this could go much longer, so be conscious of the clock.
 
 1. Invite participants and set aside at least an hour for the interviewee. Your set up for the interview will depend on why you are interviewing stakeholders or users. Many interviews can be done via a phone call, video call or screenshare application, so plan to communicate your methods in advance to anyone invited to the conversation. Whom you invite and how many interviews you should have will also depend on your reasons behind interviewing. For each interview, you should have at least two participants (a designer and an engineer for example) in attendance so that one person can act as the interviewer and the other can act as the notetaker.
 
-2. Think through your questions in advance of your conversation. What do you want to know? Basically you want to come away knowing what problem will need to solve  and who that’s a problem for. Identify any assumptions that you might have going into the interviews and document them in a text document ([Google Docs](https://docs.google.com), [Etherpad](http://etherpad.org/, or even [Github](https://github.com/)) to refer to after the interviews.  Considering that you might be using the interviews to develop other artifacts such as personas, any kind of contextual information about the interviewee might be relevant. Set up the conversation by starting with some icebreaker questions and then let the conversation play out organically. This might include:
+2. Think through your questions in advance of your conversation. What do you want to know? Basically you want to come away knowing what problem will need to solve  and who that’s a problem for. Identify any assumptions that you might have going into the interviews and document them in a text document ([Google Docs](https://docs.google.com), [Etherpad](http://etherpad.org/, or even [GitHub](https://github.com/)) to refer to after the interviews.  Considering that you might be using the interviews to develop other artifacts such as personas, any kind of contextual information about the interviewee might be relevant. Set up the conversation by starting with some icebreaker questions and then let the conversation play out organically. This might include:
 
     - How‘s the weather by you?
     - Did you catch the game last
@@ -54,7 +54,7 @@ Small (1 - 2 hours); this could go much longer, so be conscious of the clock.
 ## Examples:
 
 * [The Lyra Project](https://github.com/vega/lyra/search?q=persona&type=Issues&utf8=%E2%9C%93)
-* [Open Design Kit Interview Github Issue](https://github.com/bocoup/opendesignkit/issues/7)
+* [Open Design Kit Interview GitHub Issue](https://github.com/bocoup/opendesignkit/issues/7)
 
 ---
 

--- a/_methods/style-guides.md
+++ b/_methods/style-guides.md
@@ -34,7 +34,7 @@ Large (8+ hours)
 
 3. Discuss your findings. Walk everyone through the visuals on a video call:. Do you all agree that the elements are the repeatable ones? You may want to do something like [Charlotte Jackson's article](http://alistapart.com/article/from-pages-to-patterns-an-exercise-for-everyone) to make the inventory. Screenshot the designs and put them into a [BoardThing](http://boardthing.com/) and work on naming them together. This way you all move forward with the same vocabulary and the same ideas.
 
-4. The guide needs to get built out and put on a url somewhere that _everyone_ can see it. If you are working on Github or a wiki, make sure that you indicate the link and how to add to the guide. Also, keep in mind that a guide never really is finished (this is why it’s often called a living style guide), you'll iterate on it and change it as you iterate on the design of your site or application.
+4. The guide needs to get built out and put on a url somewhere that _everyone_ can see it. If you are working on GitHub or a wiki, make sure that you indicate the link and how to add to the guide. Also, keep in mind that a guide never really is finished (this is why it’s often called a living style guide), you'll iterate on it and change it as you iterate on the design of your site or application.
 
 ---
 

--- a/about/index.html
+++ b/about/index.html
@@ -7,7 +7,7 @@ title: About
     <div class="subpage-head">
         <h1 class="hed-a">{{page.title}}</h1>
     </div>
-    <p><a href="https://bocoup.com/">Bocoup's</a> design team maintains Open Design Kit as an <a href="https://en.wikipedia.org/wiki/Open-source_software">open source tool.</a> It's designed for collaborators who are not co-located, with a variety of skill levels. The Kit includes activities from ideation to implementation and is meant to evolve with use. To share your feedback, open an issue or pull request on our Github repository.</p>
+    <p><a href="https://bocoup.com/">Bocoup's</a> design team maintains Open Design Kit as an <a href="https://en.wikipedia.org/wiki/Open-source_software">open source tool.</a> It's designed for collaborators who are not co-located, with a variety of skill levels. The Kit includes activities from ideation to implementation and is meant to evolve with use. To share your feedback, open an issue or pull request on our GitHub repository.</p>
     <p>Each method of the kit is designed with distributed teams in mind. We did this because we believe that diverse products require diverse teams. To make a diverse team, you can’t rely on having that collaborator in the same room as you – let alone neighborhood or country! The methods here leverage digital tools such as chat, note-taking documents and screen sharing software to take advantage of the connected world that we live in.</p>
     <p>We believe that the world needs this design kit to:</p>
     <ul>

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -9,37 +9,37 @@ title: How to contribute
     </div>
 
     <h2 class="hed-a">Where we need help</h2>
-    <p> We have a ton of issues on <a href="https://github.com/bocoup/opendesignkit/issues">Github</a> specifically labeled for contributors. Right now we could use support localizing the methods, testing out the methods, and reporting outright bugs.</p>
+    <p> We have a ton of issues on <a href="https://github.com/bocoup/opendesignkit/issues">GitHub</a> specifically labeled for contributors. Right now we could use support localizing the methods, testing out the methods, and reporting outright bugs.</p>
     <h2 class="hed-a">How to contribute</h2>
     <p>If you want to contribute and help us out with the above, please either create an issue or a pull request.</p>
     <h3 class="hed-b">Create an issue</h3>
-    <p>See something you think needs to be added, but you don't have time to do it yourself? See a typo, mistake, etc. and you don't want to do a fork and fix it and then do a PR back to our repo? Just plain intimidated by Github? We get it. You can still let us know what's going on or let us know of your interest in helping us out by creating an issue.</p>
-    <p>To create an issue on Github, go to the <a href="https://github.com/bocoup/opendesignkit">Open Design Kit repository page</a> and click on “Issues” on the top tabs. From there click the “New Issue” green button on the upper right. You’ll need to be a Github user with an account to do this, so if you don’t have an account go ahead and create one!<p>
+    <p>See something you think needs to be added, but you don't have time to do it yourself? See a typo, mistake, etc. and you don't want to do a fork and fix it and then do a PR back to our repo? Just plain intimidated by GitHub? We get it. You can still let us know what's going on or let us know of your interest in helping us out by creating an issue.</p>
+    <p>To create an issue on GitHub, go to the <a href="https://github.com/bocoup/opendesignkit">Open Design Kit repository page</a> and click on “Issues” on the top tabs. From there click the “New Issue” green button on the upper right. You’ll need to be a GitHub user with an account to do this, so if you don’t have an account go ahead and create one!<p>
     <figure class="figure">
         <img src="/img/contribute/github-repo-arrow.png" alt="a view of the Open Design Kit repository, point out the issues tab" />
         <figcaption class="figcaption">The main page for the Open Design Kit repository, the “Issues” tab is second from left.</figcaption>
     </figure>
     <p>From there click the “New Issue” green button on the upper right.</p>
     <figure class="figure">
-        <img src="/img/contribute/github-issues-list-arrow.png" alt="Github issue list" />
+        <img src="/img/contribute/github-issues-list-arrow.png" alt="GitHub issue list" />
         <figcaption class="figcaption">The issue page for Open Design Kit, click the green button to start an issue.</figcaption>
     </figure>
     <p>First, give your issue a title. This should briefly but clearly identify the content, because that’s what will show up in the list of issues. Then you’ll want to tell us what’s going on. Do you want to write a method? Cool, let us know which one and what works best for you to write it, such as a Google Doc, a gist, or maybe you use something else you can share? One note: if you are familiar with markdown it’s helpful to write methods in that since we are using that as our base for the content of the site.</p>
     <figure class="figure">
-        <img src="/img/contribute/github-issue-interface.png" alt="Github issue interface" />
-        <figcaption class="figcaption">The issue interface on Github, it's helpful to write a title that easily identifies the subject matter since it shows up on the main issues list.</figcaption>
+        <img src="/img/contribute/github-issue-interface.png" alt="GitHub issue interface" />
+        <figcaption class="figcaption">The issue interface on GitHub, it's helpful to write a title that easily identifies the subject matter since it shows up on the main issues list.</figcaption>
     </figure>
     <p>You can also fill out an issue for other things you see that can be improved or need fixing, such as expanding to or adding to an existing method, typos somewhere on the site, or ideas for new parts of the kit.</p>
     <p>Once you’ve filled out all the information you think we need, hit the Submit New Issue button and we’ll get back to you!</p>
     <h3 class="hed-b">Do a Pull Request</h3>
-    <p>If you are familiar with Git and Github or if you want to get more familiar, you may be up for trying the pull request process. This is a great approach if you want to add, expand or localize content for a method (localization is an especially huge job so if you speak another language, we need your help!).</p>
-    <p>If you’re just getting started, here are some great articles to get you more comfortable and familiar with Git and Github:</p>
+    <p>If you are familiar with Git and GitHub or if you want to get more familiar, you may be up for trying the pull request process. This is a great approach if you want to add, expand or localize content for a method (localization is an especially huge job so if you speak another language, we need your help!).</p>
+    <p>If you’re just getting started, here are some great articles to get you more comfortable and familiar with Git and GitHub:</p>
     <ul>
         <li><a href="http://vallandingham.me/Quick_Git.html">Really Quick Git</a></li>
         <li><a href="http://vallandingham.me/git-workflow.html">A Series on Git Workflow</a></li>
-        <li><a href="https://akrabat.com/the-beginners-guide-to-contributing-to-a-github-project/">The Beginner's Guide to Contributing to a Github Project</a></li>
-        <li><a href="https://guides.github.com/activities/contributing-to-open-source/">Contributing to Open Source on Github</a></li>
+        <li><a href="https://akrabat.com/the-beginners-guide-to-contributing-to-a-github-project/">The Beginner's Guide to Contributing to a GitHub Project</a></li>
+        <li><a href="https://guides.github.com/activities/contributing-to-open-source/">Contributing to Open Source on GitHub</a></li>
     </ul>
-    <p>For Open Design Kit, we recommend following the outline of the article <em>Contributing to Open Source on Github</em>. If you aren't a maintainer or collaborator on Open Design Kit, you'll want to fork the repo, do your work, and then do a pull request to let us know what you've done. We can then have a discussion, if necessary, and merge in the work once it’s ready.</p>
-    <p>If you still don’t feel comfortable working with the actual code and using Git and Github, don't worry, just open an issue as outlined above and we'll figure out how to get your ideas into the kit.</p>
+    <p>For Open Design Kit, we recommend following the outline of the article <em>Contributing to Open Source on GitHub</em>. If you aren't a maintainer or collaborator on Open Design Kit, you'll want to fork the repo, do your work, and then do a pull request to let us know what you've done. We can then have a discussion, if necessary, and merge in the work once it’s ready.</p>
+    <p>If you still don’t feel comfortable working with the actual code and using Git and GitHub, don't worry, just open an issue as outlined above and we'll figure out how to get your ideas into the kit.</p>
 </section>

--- a/splashpage-copy.md
+++ b/splashpage-copy.md
@@ -1,4 +1,4 @@
 * <strong>h1</strong> Open Design Kit
-* <strong>p</strong>  A living toolkit for designing with distributed collaborators. 
-* <strong>button </strong> View on Github
-* <strong>footer</strong> [bocoup logo] Bocoup's Design team maintains Open Design Kit as an open source tool. It is useful for anyone who is designing with people who are not co-located. The Kit includes activities from ideation to implementation and is meant to evolve with use. To share your feedback or [add a method](https://github.com/bocoup/opendesignkit/wiki/Method-Guide-Template), open an issue or pull request on our Github repository.
+* <strong>p</strong>  A living toolkit for designing with distributed collaborators.
+* <strong>button </strong> View on GitHub
+* <strong>footer</strong> [bocoup logo] Bocoup's Design team maintains Open Design Kit as an open source tool. It is useful for anyone who is designing with people who are not co-located. The Kit includes activities from ideation to implementation and is meant to evolve with use. To share your feedback or [add a method](https://github.com/bocoup/opendesignkit/wiki/Method-Guide-Template), open an issue or pull request on our GitHub repository.


### PR DESCRIPTION
I noticed this in my user interview with @pamela-drouin: there are a lot of instances where we are not properly capitalizing GitHub. This patchset fixes that issue.

@iamjessklein @susanjrobertson to review.